### PR TITLE
Fixes chunked reading

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,6 @@ ReadableString.prototype._read = function (size) {
     end = size && size < buf.length ? size : buf.length
     chunk = buf.slice(0, end)
     ok = this.push(chunk)
-    this._buf = buf.slice(end, buf.length - end)
+    this._buf = buf.slice(end, buf.length)
   } while (ok && end > 0)
 }

--- a/test/stread_tests.js
+++ b/test/stread_tests.js
@@ -20,14 +20,17 @@ test('pipe', function (t) {
 })
 
 test('read', function (t) {
-  var str = 'You know what it is to be born alone, Baby tortoise!'
+  var str = '';
+  for (var i = 0; i < 400; i++) {
+    str += 'You know what it is to be born alone, Baby tortoise!';
+  }
   var reader = stread(str)
   var actual = ''
   var expected = str
 
   reader.on('readable', function () {
     var chunk = null
-    while ((chunk = reader.read(size())) !== null) {
+    while ((chunk = reader.read()) !== null) {
       actual += chunk
     }
   })
@@ -35,7 +38,4 @@ test('read', function (t) {
     t.is(actual, expected)
     t.end()
   })
-  function size () {
-    return Math.round(Math.random() * 128)
-  }
 })


### PR DESCRIPTION
When string is larger than one read operation, stread would trim results. This patch fixes that.
