### PR TITLE
Adds benchmarks

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,73 @@
+var benchmark = require('benchmark');
+var benchmarks = require('beautify-benchmark');
+var seedrandom = require('seedrandom');
+var PassThrough = require('readable-stream').PassThrough;
+var stread = require('./index');
+
+function createString(size) {
+  var buffer = new Buffer(size);
+  var rng = seedrandom('body ' + size);
+
+  for (var i = 0; i < buffer.length; i++) {
+    buffer[i] = (rng() * 94 + 32) | 0;
+  }
+
+  return buffer.toString('utf8');
+}
+
+function passThroughTest(str, encoding) {
+  encoding = encoding || 'utf8'
+  const s = new PassThrough({ encoding: encoding })
+  s.end(str)
+  return s
+}
+
+function readStream(stream, deferred) {
+  stream.on('data', function(chunk) {});
+  stream.on('end', function () {
+    deferred.resolve();
+  });
+}
+
+var suite = new benchmark.Suite();
+
+suite.on('start', function(e) {
+  return process.stdout.write('Working...\n\n');
+});
+
+suite.on('cycle', function(e) {
+  return benchmarks.add(e.target);
+});
+
+suite.on('complete', function() {
+  return benchmarks.log();
+});
+
+function addTest(stringSize) {
+  var string = createString(stringSize);
+
+  suite.add('stread ' + stringSize, {
+    defer: true,
+    minSamples: 100,
+    fn: function(deferred) {
+      readStream(stread(string), deferred);
+    }
+  });
+
+  suite.add('PassThrough ' + stringSize, {
+    defer: true,
+    minSamples: 100,
+    fn: function(deferred) {
+      readStream(passThroughTest(string), deferred);
+    }
+  });
+}
+
+addTest(10);
+addTest(100);
+addTest(1 * 1024);
+addTest(10 * 1024);
+addTest(100 * 1024);
+addTest(1000 * 1024);
+
+suite.run({ async: false });

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ function ReadableString (str) {
   if (!(this instanceof ReadableString)) return new ReadableString(str)
   Readable.call(this)
   this._buf = new Buffer(str)
+  this._pos = 0
 }
 util.inherits(ReadableString, Readable)
 
@@ -18,14 +19,15 @@ ReadableString.prototype._read = function (size) {
   var end = 0
   do {
     var buf = this._buf
-    if (buf === null || buf.length === 0) {
+    if (buf === null || this._pos >= buf.length) {
       this.push(null)
       this._buf = null
+      this._pos = 0
       break
     }
-    end = size && size < buf.length ? size : buf.length
-    chunk = buf.slice(0, end)
+    end = size && this._pos + size < buf.length ? this._pos + size : buf.length
+    chunk = buf.slice(this._pos, end)
     ok = this.push(chunk)
-    this._buf = buf.slice(end, buf.length)
+    this._pos += end
   } while (ok && end > 0)
 }

--- a/index.js
+++ b/index.js
@@ -26,6 +26,6 @@ ReadableString.prototype._read = function (size) {
     end = size && size < buf.length ? size : buf.length
     chunk = buf.slice(0, end)
     ok = this.push(chunk)
-    this._buf = buf.slice(end, buf.length - end)
+    this._buf = buf.slice(end, buf.length)
   } while (ok && end > 0)
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "example": "example",
     "test": "test"
   },
+  "files": [
+    "index.js"
+  ],
   "scripts": {
     "test": "tap test/*.js"
   },
@@ -23,6 +26,9 @@
     "stream"
   ],
   "devDependencies": {
+    "beautify-benchmark": "^0.2.4",
+    "benchmark": "^2.1.1",
+    "seedrandom": "^2.4.2",
     "tap": "^1.2.0"
   },
   "engines": {

--- a/test/stread_tests.js
+++ b/test/stread_tests.js
@@ -20,14 +20,17 @@ test('pipe', function (t) {
 })
 
 test('read', function (t) {
-  var str = 'You know what it is to be born alone, Baby tortoise!'
+  var str = '';
+  for (var i = 0; i < 400; i++) {
+    str += 'You know what it is to be born alone, Baby tortoise!';
+  }
   var reader = stread(str)
   var actual = ''
   var expected = str
 
   reader.on('readable', function () {
     var chunk = null
-    while ((chunk = reader.read(size())) !== null) {
+    while ((chunk = reader.read()) !== null) {
       actual += chunk
     }
   })
@@ -35,7 +38,4 @@ test('read', function (t) {
     t.is(actual, expected)
     t.end()
   })
-  function size () {
-    return Math.round(Math.random() * 128)
-  }
 })


### PR DESCRIPTION
With my latest change that reuses the same buffer, `stread` is more than 2x faster than `PassThrough` with smaller buffers and almost 2x faster with larger buffers (1mb).

```
$ node --version
6.3.0

$ node benchmark.js
Working...

  12 tests completed.

  stread 10           x 56,735 ops/sec ±1.82% (170 runs sampled)
  PassThrough 10      x 25,332 ops/sec ±1.65% (168 runs sampled)
  stread 100          x 56,694 ops/sec ±1.58% (172 runs sampled)
  PassThrough 100     x 24,520 ops/sec ±1.81% (166 runs sampled)
  stread 1024         x 54,276 ops/sec ±1.40% (173 runs sampled)
  PassThrough 1024    x 23,258 ops/sec ±1.99% (170 runs sampled)
  stread 10240        x 30,070 ops/sec ±1.24% (168 runs sampled)
  PassThrough 10240   x 18,974 ops/sec ±1.80% (168 runs sampled)
  stread 102400       x  7,502 ops/sec ±1.63% (162 runs sampled)
  PassThrough 102400  x  7,553 ops/sec ±1.49% (171 runs sampled)
  stread 1024000      x    890 ops/sec ±1.14% (165 runs sampled)
  PassThrough 1024000 x    540 ops/sec ±1.47% (165 runs sampled)
```
